### PR TITLE
Fix README grammar and add copy feature

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -27,16 +27,22 @@
 			</svg>
 			Download Text
 		</a>
-		<a id="download-html-link">
-			<svg class="feather">
-				<use xlink:href="/icons/feather-sprite.svg#save" />
-			</svg>
-			Download HTML
-		</a>
-	</div>
-	<div class="footer">
-		<p>you can edit the urls</p>
-	</div>
+                <a id="download-html-link">
+                        <svg class="feather">
+                                <use xlink:href="/icons/feather-sprite.svg#save" />
+                        </svg>
+                        Download HTML
+                </a>
+                <a id="copy-link">
+                        <svg class="feather">
+                                <use xlink:href="/icons/feather-sprite.svg#save" />
+                        </svg>
+                        Copy
+                </a>
+        </div>
+        <div class="footer">
+                <p>You can edit the URLs</p>
+        </div>
 	<script src="popup.js"></script>
 </body>
 

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 var mainTextarea = document.getElementById("main-textarea");
 var downloadLink = document.getElementById("download-link");
 var downloadHTMLLink = document.getElementById("download-html-link");
+var copyLink = document.getElementById("copy-link");
 var tabURLs = []; // Need to refactor to not have this in public scope.
 
 function updateTabURLs() {
@@ -29,6 +30,13 @@ downloadLink.addEventListener("click", () => {
 });
 downloadHTMLLink.addEventListener("click", () => {
   downloadHTMLPage(tabURLs);
+});
+copyLink.addEventListener("click", () => {
+  navigator.clipboard.writeText(mainTextarea.value).then(() => {
+    var original = copyLink.textContent;
+    copyLink.textContent = "Copied!";
+    setTimeout(() => { copyLink.textContent = original; }, 1000);
+  });
 });
 
 function createDownloadFile(data, filename, type) {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This Chrome extension allows you to save all the URLs from your open tabs into a text file.Additionally, it provides a feature to download an HTML page containing all the links from the active tab.
+This Chrome extension allows you to save all the URLs from your open tabs into a text file. Additionally, it provides a feature to download an HTML page containing all the links from the active tab.
 
 ## Installation
 
@@ -28,7 +28,9 @@ This Chrome extension allows you to save all the URLs from your open tabs into a
 
 3. Click on the "Download Text" button to save the URLs as a text file.
 
-4. Click on the "Download HTML" button to save the URLs as a HTML file.
+4. Click on the "Download HTML" button to save the URLs as an HTML file.
+
+5. Click on the "Copy" button to copy all URLs to your clipboard.
 
 ## Contributions
 

--- a/style.css
+++ b/style.css
@@ -50,7 +50,25 @@ body {
     transition-duration: 0.2s;
 }
 
+#copy-link {
+    display: block;
+    padding: 10px 20px 10px 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    color: #fff;
+    font-size: 18px;
+    font-weight: bold;
+    text-decoration: none;
+    text-align: center;
+    background-color: #007bff;
+    border-radius: 5px;
+    transition-duration: 0.2s;
+}
+
 #download-link:hover {
+    background-color: #0056b3;
+}
+#copy-link:hover {
     background-color: #0056b3;
 }
 #download-html-link {


### PR DESCRIPTION
## Summary
- fix grammatical issue in README
- correct footer text in popup
- add Copy button to popup UI
- style new button
- implement clipboard copy logic

## Testing
- `npm test` *(fails: package.json missing)*